### PR TITLE
Allow limelight to switch pipelines

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -34,6 +34,7 @@ import frc.robot.subsystem.SystemLights;
 import frc.robot.subsystem.Elevator.Position;
 import frc.robot.subsystem.EndEffector.AlgaeServoPosition;
 import frc.robot.subsystem.EndEffector.HeadPosition;
+import frc.robot.subsystem.Limelight.LimeLightPipeline;
 import frc.robot.subsystem.SystemLights.PresetColor;
 import frc.robot.util.ReefScoringMap;
 
@@ -372,6 +373,10 @@ public class RobotContainer {
         SmartDashboard.putData(elevator.cmdAddRotations(-1));
 
         SmartDashboard.putData(elevator.cmdResetPos());
+
+        // Limelight
+        SmartDashboard.putData(limelight.switchPipeline(LimeLightPipeline.MORNING));
+        SmartDashboard.putData(limelight.switchPipeline(LimeLightPipeline.EVENING));
     }
 
     private void addPathAuto(String name, String pathName) {

--- a/src/main/java/frc/robot/subsystem/Limelight.java
+++ b/src/main/java/frc/robot/subsystem/Limelight.java
@@ -4,7 +4,6 @@
 
 package frc.robot.subsystem;
 
-import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -56,7 +55,9 @@ public class Limelight extends SubsystemBase {
   }
 
   public Command switchPipeline(LimeLightPipeline limeLightPipeline) {
-    return Commands.runOnce(() -> LimelightHelpers.setPipelineIndex(name, limeLightPipeline.pipelineId));
+    return Commands.runOnce(() -> LimelightHelpers.setPipelineIndex(name, limeLightPipeline.pipelineId))
+        .withName(String.format("%s set pipeline %s", name, limeLightPipeline.toString()))
+        .ignoringDisable(true);
   }
 
   @Override


### PR DESCRIPTION
- Added command that will update the pipeline network table for the limelight so that it switch pipelines
- Added command buttons to the smartdashboard (the current pipeline is already available under limelight in the network tables)